### PR TITLE
Add Lotus Launch Specifications to the documents Specifications

### DIFF
--- a/content/en/docs/specs/lotus/_index.md
+++ b/content/en/docs/specs/lotus/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Lotus Specifications"
+linkTitle: "Lotus Specifications"
+weight: 50
+---
+
+{{% pageinfo %}}
+This is the main area for Lotus specifications. Some details are currently located in the bitcion and bitcoincash specifications until moved.
+{{% /pageinfo %}}
+

--- a/content/en/docs/specs/lotus/addresses.md
+++ b/content/en/docs/specs/lotus/addresses.md
@@ -1,0 +1,86 @@
+---
+title: "Address Format"
+linkTitle: "Address Format"
+weight: 60
+---
+
+## Rationale
+
+Currently, Bitcoin Cash, and Bitcoin ABC, from which Lotus is dervived, use the cashaddr address format. However, Lotus needs a new address type for taproot outputs. This requires substantial changes to the cashaddr parsing libraries and specification as well as wallets. To use `cashaddr` as a basis for supporting taproot, there would be a need to fork the libraries and modify the cashaddr specification. Additionally, cashaddr has the following weaknesses:
+
+1. It requires base32 encoding which is not readily available as a library in many languages.
+2. It requires a custom BCH checksum, which is complex and requires custom implementations along side the address parser
+3. The checksum is not done on the raw string address. Thus, it requires parsing the address, recombining the portions that are included in the checksum, and producing the checksum or verifying it. This means the checksum verification code must be entangled with the parsing code.
+4. The payload includes a version byte which is encodes a size as well as a type.
+    * This results in potentially nonsensical combinations such as P2SH with size 32 instead of 20. If this were supported in the future, wallets would need to implement this as a separate type of output. This causes implementations to branch on both the size and the type in order to determine the output time.
+    * The sizes available per the specification only support certain commitment sizes. For a taproot address w/ commitment 65 bytes is needed which is not supported.
+5. Because the prefix is optional - but also included in the checksum - it requires wallets to provide a default prefix that must change based on the network it is running on. This conflates the token type with the network and requires a mapping table for different networks of the same coin. (e.g. `bchtest` vs `bitcoincash` vs `ecash`). It also means that a general address translator for converting a testnet address to a mainnet address must guess the network and try repeated 
+
+Due to the following weaknesses above, and the need to fork the libraries and modify the cashaddr specification. The type byte would need to be modified to support additional sizes, as well as implementing a new address type in Lotus-supporting wallets. Additionally, if new address types were added, all wallets would need to be updated to support it.
+
+Thus, we propose an entirely new format. This format should meet the following requirements.
+
+1. Able to be double-clicked and copied.
+2. Uses commonly available language primitives to obviate needing to implement complicated checksum algorithms
+3. Checksum can be verified without parsing the individual components of the address string.
+4. Should be unspecific to token being addressed.
+5. Validity of the token prefix and the network are offloaded to the user of libraries which called the parser.
+6. Forward compatibility of new address formats with legacy wallets.
+
+By creating an address specification that meets the above requirements, developers can easily implement it in any language they are working with. The address format is also forward-compatible so that wallets would not necessarily need to be updated in the future to support new address types.
+
+## Proposed Format
+
+`[payto:]<token identifier><network byte><Base58(payload)><Pad(Base58(weak hash))>[?query string]`
+
+### Payto (Optional)
+
+This field is entirely optional and is suggested to be similar to `mailto:` It can be used optionally to provide a way to automatically launch a wallet using a link. Please note, this would mean that only one application could register for these payment links, and they would either need to support all tokens or delegate to another app. This cannot be specified here in a forward-thinking way, and the solution is left to the time when the need arises.
+
+### Token identifier
+
+Token identifier must be all lowercase word characters [a-z0-9]. For lotus this would generally be `lotus`
+
+### Network byte
+
+A single byte identifier used to verify the intended network for the transaction. It must be in the set of characters: \[_A-Z\]. Currently the specified networks are:
+
+1. `_` - mainnet
+2. `T` - testnet
+3. `R` - regtest
+
+### Payload
+
+This can be any string of bytes relevant to the chain being worked with. Other layers can be built on top of a basic address parser with handles this payload based on token type. For Lotus, the intent is that this would be an entire UTXO. Currently valid standard UTXOs are:
+
+1. BIP016 P2SH: `OP_HASH160 <20-byte-hash-value> OP_EQUAL`
+2. P2PKH: `OP_DUP OP_HASH160 <20-byte-hash-value> OP_EQUALVERIFY OP_CHECKSIG`
+3. Taproot: `OP_SCRIPTTYPE OP_1 <33 byte pubkey [|| 32 byte SHA256 commitment]>`
+
+### Weak hash
+
+The checksum consists of the last four bytes (weak SHA256) of the SHA256 hash of the preceding portions of the address:
+
+`<token identifier><network byte><Base58(payload)>`
+
+It is then itself base58 encoded, which results in at most 6 bytes. If it is less than 6 bytes, the ASCII character `1` is padded onto the left of the encoded weak hash. This enables parsers to slice the last 6 bytes off the address and base58 decode them without a delimeter. In most cases the encoded hash of the payload will be 6 bytes. Thus, adding padding in the minority of cases does not result in further size.
+
+Unlike Cashaddr, this checksum does not provide any error correction via a BCH code. However, the BCH code specified for cashaddr is specific to that address format and requires re-implementation in every language. This can be non-trivial to do in languages which do not easily support the required integer and bitwise operations.
+
+However, in most cases users are copying and pasting addresses, and this address format is optimized for that use case. BCH error-correcting checksums allow for correcting mistaken characters. However, it is discouraged for wallets to provide anything but a notification of which characters were entered incorrectly. This would only happen when the address is hand-typed from another device. In these cases, inter-device address transmission happens via a QR code. The specification for QR codes and associated libraries include their own BCH checksum to ensure the ability fo fix misreads.
+
+### Query string (Optional)
+
+This is an optional portion of the address. Any parameters supported by wallets in the future can be added. However, some parameters should be implemented by all wallets. At this time they are
+
+1. amount - The number of atomic units of the token to send.
+
+## Example:
+
+The following is an example of how an an address would look for lotus.
+
+`payto:lotus_42U4tGcVko7D139rAPvusmZ65QSvx2MwHbtY`
+
+## Conclusion
+
+This format is easily selectable, improving usability. It's more compact than cashaddrs due to returning to base58. It also provides an encoding and an integrity check which uses primitives available readily in most languages. Additionally, because the payload is the precise UTXO, it does not require primitive wallets to be updated to support new address formats.

--- a/content/en/docs/specs/lotus/blockheader.md
+++ b/content/en/docs/specs/lotus/blockheader.md
@@ -1,0 +1,92 @@
+---
+title: "Block Header"
+linkTitle: "Block Header"
+weight: 70
+---
+
+The hash algorithm is multiple iterations of SHA256 that are layered on top of each other via hash commitments. This allows low resource devices to prune various unimportant data.
+
+Usage: Entropy, Blockchaining
+
+The header data structure looks as follows:
+
+| Size | Name | Meaning |
+|------|------|---------|
+| 32 bytes | hashPrevBlock | Previous block hash |
+| 4 bytes | nBits | Compact encoding of the target for this block |
+| 6 bytes | nTime | Timestamp of the block (UNIX time), good for 8 million years |
+| 2 bytes | nReserved | Reserved for future use, always 0x0000 |
+| 8 bytes | nNonce | Nonce for miners to tweak the hash |
+| 1 bytes | nMetaVersion | Version for the data that follows; it should not yet be considered set in stone |
+| 7 bytes | nSize | Block size in bytes |
+| 4 bytes | nHeight | Block height, where the genesis block is 0 |
+| 32 bytes | hashEpochBlock | Hash of the last block which had a height divisible by 5040 |
+| 32 bytes | hashMerkleRoot | Merkle root of the transactions of the block |
+| 32 bytes | hashExtendedMetadata | Hash of the extended metadata |
+
+### Layer 1 Header: Chain Layer
+
+This layer allows to very cheaply verify that the blocks form a chain and that PoW has been performed.
+
+Can also be used as a very cheap entropy source if previous block hash is known.
+
+| Size | Name | Meaning |
+|------|------|---------|
+| 32 bytes | hashPrevBlock | Previous block hash |
+| 32 bytes | hashPowLayer | SHA256 of Layer 2 Metadata |
+
+### Layer 2 Header: PoW Layer
+
+This layer allows to verify the PoW and DAA (ASERT only requires time and height).
+
+SPV wallets can store only this layer for blocks that don't contain txs.
+
+A 6 byte timestamp is good for 8 million years; until then we will have reversed SHA256 anyway and have to do a PoW change.
+
+| Size | Name | Meaning |
+|------|------|---------|
+| 4 bytes | nBits | Compact encoding of the target for this block |
+| 6 bytes | nTime | Timestamp of the block (UNIX time) |
+| 2 bytes | nReserved | Reserved for future use, always 0x0000 |
+| 8 bytes | nNonce | Nonce for miners to tweak the hash |
+| 32 bytes | hashTxLayer | SHA256 of Layer 3 Metadata |
+
+### Layer 3 Header: Tx layer
+
+This contains the txs merkle root, so we can verify the transactions of the block.
+
+SPV wallets store this layer for blocks that do contain txs they're interested in.
+
+Epochs are 7 days and allow skipping many blocks while still knowing they're connected. This is useful for very low spec devices and smart contracts.
+
+| Size | Name | Meaning |
+|------|------|---------|
+| 1 bytes | nMetaVersion | Version for the data that follows; it should not yet be considered set in stone |
+| 7 bytes | nSize | Block size in bytes |
+| 4 bytes | nHeight | Block height, where the genesis block is 0 |
+| 32 bytes | hashEpochBlock | Epoch block hash, 5040 block epochs (7 days) |
+| 32 bytes | hashMerkleRoot | Txs Merkle root |
+| 32 bytes | hashExtendedMetadata | Extended Metadata SHA256d hash |
+
+### Layer 4: Extended Metadata
+
+This layer is currently unused, and is enforced as the SHA256d of `0` as consensus. However, in the future it is intended to contain additional data that may become relevant for consensus.
+
+Although this could change in the future due to the current enforcement, the currently intended format is:
+
+Optional fields are:
+* `1`: extra nonce (1-32 bytes), to tweak the hash some more.
+* `2`: memo (1-32 bytes), to leave some arbitrary message
+
+| Type | Meaning |
+|------|---------|
+| var_int | number of fields |
+| metadata_field[] | fields |
+
+Metadata field format:
+
+| Type | Meaning |
+|------|---------|
+| 4 bytes | field ID |
+| var_int | length |
+| uchar[] | data |

--- a/content/en/docs/specs/lotus/script/_index.md
+++ b/content/en/docs/specs/lotus/script/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Script"
+linkTitle: "Script"
+weight: 50
+---
+
+# Basic Script
+
+Lotus script is is generally compatible with Bitcoin some backwards compatible changes:
+
+* Opcode Limit: 400 opcodes
+* Integer operators operate on 64 bit ones-complement signed integers.
+* Addition of many previously disabled opcodes

--- a/content/en/docs/specs/lotus/script/opcodes.md
+++ b/content/en/docs/specs/lotus/script/opcodes.md
@@ -1,0 +1,55 @@
+---
+title: "Opcodes"
+linkTitle: "Opcodes"
+weight: 60
+---
+
+# Basic Script
+
+Differences from Bitcoin:
+
+* Opcode Limit: 400 opcodes
+* Integer operators operate on 64 bit ones-complement signed integers.
+
+## Bitwise Operators
+
+### OP_XOR
+
+```
+a b OP_XOR -> c
+```
+
+Same specification as Bitcoin Cash with the requirement that the operands be the same size removed.
+
+### OP_AND
+
+```
+a b OP_AND -> c
+```
+
+Same specification as Bitcoin Cash with the requirement that the operands be the same size removed.
+
+### OP_NUM2BIN
+
+```
+a b OP_NUM2BIN -> c
+```
+
+Same specification as Bitcoin Cash with the requirement that the BIN size must be less than or equal to 68 bytes.
+
+### OP_RAWBITSHIFT
+
+```
+a b OP_RAWBITSHIFT -> c
+```
+
+Pops the top two stack elements. Shifts the top stack element left by `b` bits. `b` may be negative. Overflows, drop excess bits.
+
+### OP_MULPOW2
+
+```
+a b OP_MULPOW2 -> c
+```
+
+Pops the top two stack elements. Multiplies `a` by `2^b`. `b` may be negative. Overflows result in a script error.
+

--- a/content/en/docs/specs/lotus/script/taproot.md
+++ b/content/en/docs/specs/lotus/script/taproot.md
@@ -1,0 +1,15 @@
+---
+title: "Taproot"
+linkTitle: "Taproot"
+weight: 70
+---
+
+Taproot implementation is compatible with BIP341. However, the output to use taproot consists of a matched pattern of the form:
+
+```
+OP_SCRIPTTYPE OP_1 <33-byte commitment [ || 32 byte commitment]>
+```
+
+The 33 byte commitment is pubkey of the same form as the BIP341 specification. However, BIP341 uses a commitment to the x value of the pubkey only.
+
+The optional 32 byte commitment is pushed onto the script stack immediately before executing the taproot spend paths.

--- a/content/en/docs/specs/lotus/subsidy.md
+++ b/content/en/docs/specs/lotus/subsidy.md
@@ -1,0 +1,111 @@
+---
+title: "Block Reward"
+linkTitle: "Block Reward"
+weight: 80
+---
+
+Coin issuance in Lotus is adjusted compared to bitcoin in the following ways:
+* The [issuance](#issuance) of Coinbase rewards will are `260 * log2(difficulty)` megasats.
+* Half of transaction fees are burned.
+* Half of remaining block reward (subsidy + fees) will be distributed to miners,
+  and the other half will goto thirteen selected projects. Currently, the
+  mechanism of project selection is determined by the node development team, but
+  will evolve later based on community desires. The projects are as follows:
+  1. Lotus Development Team
+  2. StampChat
+  3. Be.Cash
+  4. Bitcoin ABC
+  5. Saipan Institute
+  6. Humanitarian Lotus User Group
+  7. TBD
+  8. TBD
+  9. TBD
+  10. TBD
+  11. TBD
+  13. TBD
+
+## Issuance
+
+Coinbase rewards will be changed to be `260 * (log2(difficulty) + 1)` megasats
+using a fixed-point logarithm with precision `2**16`.
+
+### Rationale
+
+This allows for some inflation based on the difficulty target of the chain. The
+difficulty itself is a function of token value, and mining electrical
+efficiency. Increases in mining efficiency, historically have been exponential,
+by taking the log of the difficulty, efficiency increases are linearized and
+represent a fixed multiple of the base 260 megasats. Over time, the base reward
+will become an insignificant amount of the total coins in circulation making
+lotus inflationary, but at an ever decreasing percentage. 
+
+However, the reward will also adjust on short timescales to changes in price.
+The impact of this is that there is some effect on token supply in order to
+suppress volatility. The intent is to make the token more useful, while still
+providing limited supply.
+
+### Algorithm
+
+The algorithm is based on nBits which is a compressed floating-point
+representation of the target. In C++ the algorithm uses fixed-point integer math
+and is as follows:
+
+```C++
+Amount GetBlockSubsidy(uint32_t nBits,
+                       const Consensus::Params &consensusParams) {
+    static constexpr int64_t SUBSIDY_INT = SUBSIDY / SATOSHI;
+    static constexpr int64_t PRECISION_BITS = 16;
+    static constexpr int64_t LOG_MAX_TARGET = 224;
+    const int32_t exp = nBits >> 24;
+    const uint32_t mantissa = (nBits & 0x007fffff);
+
+    const int64_t logMantissaFixedPoint =
+        Log2FixedPoint(mantissa, PRECISION_BITS);
+    const int64_t aUncorrectedLogMantissa =
+        (SUBSIDY_INT * logMantissaFixedPoint) >> PRECISION_BITS;
+    const int64_t aLogMantissa = aUncorrectedLogMantissa + SUBSIDY_INT * PRECISION_BITS;
+    const int64_t aLogExponent = SUBSIDY_INT * (8 * (exp - 3));
+    const int64_t aLogTarget = aLogMantissa + aLogExponent;
+    int64_t blockSubsidy = SUBSIDY_INT * LOG_MAX_TARGET - aLogTarget;
+    blockSubsidy += SUBSIDY_INT;
+    return blockSubsidy * SATOSHI;
+}
+```
+
+Where `Log2FixedPoint` is implemented as follows:
+
+```C++
+int32_t Log2FixedPoint(uint32_t x, const size_t precision) {
+    int32_t b = 1U << (precision - 1);
+    int32_t y = 0;
+
+    assert(precision >= 1 && precision <= 31);
+
+    if (x == 0) {
+        return std::numeric_limits<int32_t>::min(); // negative infinity
+    }
+
+    while (x < 1U << precision) {
+        x <<= 1;
+        y -= 1U << precision;
+    }
+
+    while (x >= 2U << precision) {
+        x >>= 1;
+        y += 1U << precision;
+    }
+
+    uint64_t z = x;
+
+    for (size_t i = 0; i < precision; i++) {
+        z = (z * z) >> precision;
+        if (z >= 2U << precision) {
+            z >>= 1;
+            y += b;
+        }
+        b >>= 1;
+    }
+
+    return y;
+}
+```

--- a/content/en/docs/specs/lotus/upgrades/_index.md
+++ b/content/en/docs/specs/lotus/upgrades/_index.md
@@ -1,0 +1,10 @@
+---
+title: "Upgrades"
+linkTitle: "Upgrades"
+weight: 1
+---
+
+{{% pageinfo %}}
+This area contains all the upgrade relevant changes with links to the specific specifications. This section is meant to help developers implement future upgrades. The rest of the specifications are organized topically to assist developers who generally look up information topically.
+{{% /pageinfo %}}
+

--- a/content/en/docs/specs/lotus/upgrades/genesis.md
+++ b/content/en/docs/specs/lotus/upgrades/genesis.md
@@ -1,0 +1,66 @@
+
+---
+title: "Genesis"
+linkTitle: "Genesis"
+weight: 10
+---
+
+## Summary of Changes
+
+Lotus will be based on the Bitcoin ABC codebase and specifications, with the following changes upon initial launch.
+
+* New Genesis Block
+* Removal of all fork activation code
+* Reset difficulty to 1
+* New Netmagic and Diskmagic Values
+* [Extended Header Format]({{< ref "../blockheader" >}})
+* Blocktime to 2 minutes
+* [New address format]({{< ref "../addresses" >}})
+* [Economic adjustments]({{< ref "../subsidy" >}})
+  * The issuance of Coinbase rewards will be changed to be `260 * log2(difficulty)` megasats.
+    * Half will go to miners
+    * Half will go to servicing the blockchain and users through a selection of various projects which support the
+      public good.
+  * Half of fees will be burned, the 25% will go to miners and another 25% will go selected projects.
+* Enforce all standardness rules as consensus
+* [Script changes]({{< ref "../script" >}}):
+  * Increase opcode limit to 400 opcodes
+  * [Relax OP_XOR and OP_AND operand size constraints]({{< ref "../script/opcodes" >}}#bitwise-operators)
+  * [Add OP_RAWBITSHIFT]({{< ref "../script/opcodes" >}}#op_rawbitshift)
+  * [Add OP_MULPOW2]({{< ref "../script/opcodes" >}}/#op_mulpow2)
+  * Limit NUM2BIN to 68 bytes
+  * Increase integer sizes from 32 bits to 64 bit ones-complement signed integers
+  * Disable all unusable opcodes and reserve them for future hardforks
+  * [Add Taproot support and BIP341 signatures]({{< ref "../script/taproot" >}})
+
+## Genesis Block
+
+A new genesis block will be used. Lotus is not a fork of the blockchain, but is using the Bitcoin codebase.
+
+## Difficulty Reset
+
+Due to starting fresh, the difficulty will be reset to a target of 1 initially similar to the original Bitcoin launch.
+
+## Removal of Activation
+
+Due to the fresh start of the blockchain, all activation code for previous soft and hardforks have been removed. These features
+will be available from launch.
+
+## Magic Values
+
+The diskmagic, and netmagic will be changed to the following values:
+
+* Diskmagic: `ldsk` with most-significant-bit set.
+* Netmagic: `lgos` with most-significant-bit set.
+
+## Economic adjustments
+
+The block reward will be 260 megasats per block + half fees. The other half of fees will be discarded. Additionally, this reward will be split between miners and developers evenly. The development reward will be shared between a variety of projects and determined every 6 months by the Logos foundation.
+
+## Blocktimes
+
+The target blocktime will be reduced from 10 minutes to 2 minutes. This allows faster confirmations, and has been requested for for Bitcoin ABC for a long time. Additionally, it reduces block variance significantly.
+
+## Enforce all standardness rules as consensus
+
+Currently, Bitcoin variants have relaxed constraints on what is acceptable in a block versus standardness checks. Lotus now enforces all standardness checks on new blocks as well.


### PR DESCRIPTION
As per title. These currently only include specifications for items
which diverge from the BCH/BCHA blockchains. However, the structure
of the folder is to be topical-based rather than activation time based.
Each future commit should be a single commit which includes all the
changes and activation times of new features.

This enables easy updating of the specifications, as well as an easy
to use reference -- rather than needing to look through activation-time
organized specifications.