### PR TITLE
Fix XAddress specification's regarding integrity bytes

### DIFF
--- a/content/en/docs/specs/lotus/addresses.md
+++ b/content/en/docs/specs/lotus/addresses.md
@@ -58,7 +58,7 @@ This can be any string of bytes relevant to the chain being worked with. Other l
 
 ### Weak hash
 
-The checksum consists of the last four bytes (weak SHA256) of the SHA256 hash of the other portions of the address:
+The checksum consists of the first four bytes (weak SHA256) of the SHA256 hash of the other portions of the address:
 
 `<token identifier><network byte><payload>`
 


### PR DESCRIPTION
The specification currently says that the last four bytes are used from
the hash of the address contents to validate its integrity. However, the
code actually uses the *first* four bytes to match the original Bitcoin
check format.