### PR TITLE
Add TxID spec to documentation of Lotus

### DIFF
--- a/content/en/docs/specs/lotus/txid.md
+++ b/content/en/docs/specs/lotus/txid.md
@@ -1,0 +1,58 @@
+---
+title: "Transaction IDs"
+linkTitle: "Transaction IDs"
+weight: 70
+---
+
+The Lotus Tansaction ID is calculated differently than for BTC, BCH, or eCash.
+It includes what was a planned feature on Bitcoin Cash called "MalFix" or
+malleability fix for short. This basically means that the "Script Signature" is
+not covered by the transaction ID hash.
+
+The purpose of this is to prevent the transaction ID from being mutable due to
+the fact that ScriptSig data is not covered by transaction signatures and may be
+modified by third parties. This is similar in intent to Segregated Witness, but
+is done for all transactions rather than only SegWit transactions.
+
+This is resiable for two reasons:
+
+1. It allows the implementation of the lightning network
+2. Prevents third parties from executing malleability attacks which can cause
+   transaction chains to become invalidated.
+
+Instead of simply excluding the ScriptSigs from the calculation, the Lotus
+transaction ID is merklelized in order to allow more powerful scripting
+abilities such as miner-verified tokens. It additionally corresponds to the
+format of the Lotus Taproot Signature format. This allows a script to easily
+calculate it's own TxID for covenant verifications.
+
+# Format
+
+
+| Size | Name | Meaning |
+|------|------|---------|
+| 4 bytes | nVersion | Transaction version |
+| 32 bytes | nInRoot | Merkle root of the transaction inputs |
+| 1 byte | nInHeight | Height of the input merkle root  |
+| 32 bytes | nOutRoot | Merkle root of the transaction out |
+| 1 byte | nOutHeight | Height of the outputs merkle root  |
+| 4 bytes | nLockTime | Transaction locktime |
+
+# C++ Example
+
+```C++
+static uint256 ComputeTxId(int32_t nVersion, const std::vector<CTxIn> &vin,
+                           const std::vector<CTxOut> &vout,
+                           uint32_t nLockTime) {
+    CHashWriter txid(SER_GETHASH, 0);
+    size_t height;
+    txid << nVersion;
+    txid << TxInputsMerkleRoot(vin, height);
+    txid << uint8_t(height);
+    txid << TxOutputsMerkleRoot(vout, height);
+    txid << uint8_t(height);
+    txid << nLockTime;
+    return txid.GetHash();
+}
+```
+

--- a/content/en/docs/specs/lotus/txid.md
+++ b/content/en/docs/specs/lotus/txid.md
@@ -1,7 +1,7 @@
 ---
 title: "Transaction IDs"
 linkTitle: "Transaction IDs"
-weight: 70
+weight: 90
 ---
 
 The Lotus Tansaction ID is calculated differently than for BTC, BCH, or eCash.

--- a/content/en/docs/specs/lotus/upgrades/genesis.md
+++ b/content/en/docs/specs/lotus/upgrades/genesis.md
@@ -23,6 +23,7 @@ Lotus will be based on the Bitcoin ABC codebase and specifications, with the fol
       public good.
   * Half of fees will be burned, the 25% will go to miners and another 25% will go selected projects.
 * Enforce all standardness rules as consensus
+* [MalFix]({{< ref "../txid.md" >}})
 * [Script changes]({{< ref "../script" >}}):
   * Increase opcode limit to 400 opcodes
   * [Relax OP_XOR and OP_AND operand size constraints]({{< ref "../script/opcodes" >}}#bitwise-operators)


### PR DESCRIPTION
The TxID change was lost in the shuffle of doing the initial genesis
release. This commit includes it in the list of changes and adds a basic
technical specification for how TxIDs are calculated.