### PR TITLE
Remove direct references to exbitron

### DIFF
--- a/app/static/lang/de-DE.js
+++ b/app/static/lang/de-DE.js
@@ -1,5 +1,5 @@
 export default () => {
-  return new Promise(function(resolve) {
+  return new Promise(function (resolve) {
     resolve({
       common: {
         title: '',
@@ -156,19 +156,14 @@ export default () => {
           q3: {
             question: 'Wie bekomme ich Lotus?',
             answer:
-              'Du kannst unseren <a href="https://faucet.lotuslounge.org/" target="_blank">Faucet</a>. Oder du kannst dich in unserer <a href="https://t.me/givelotus" target="_blank">Telegram Gruppe</a> beschenken lassen. Du kannst auch deine anderen Coins für Lotus [XPI] auf der <a href="https://www.exbitron.com/" target="_blank">Exbitron Handelsplattform</a> tauschen.',
+              'Du kannst unseren <a href="https://faucet.lotuslounge.org/" target="_blank">Faucet</a>. Oder du kannst dich in unserer <a href="https://t.me/givelotus" target="_blank">Telegram Gruppe</a> beschenken lassen.',
           },
           q4: {
-            question: 'Wo kann ich Lotus handeln?',
-            answer:
-              'Du kannst Lotus auf Exbitron für <a href="https://www.exbitron.com/trading/xpiusdt" target="_blank">USDT</a>, <a href="https://www.exbitron.com/trading/xpidoge" target="_blank">Dogecoin</a> und <a href="https://www.exbitron.com/trading/xpibch" target="_blank">Bitcoin Cash</a> handeln.',
-          },
-          q5: {
             question: 'Wie kann ich zum Projekt beitragen?',
             answer:
               'Du kannst unseren open-source Code <a href="https://github.com/LogosFoundation" target="_blank">hier</a> ansehen und Änderungen vorschlagen, und du kannst dich gerne an die Entwickler in der <a href="https://t.me/givelotus" target="_blank">Telegram Gruppe</a> wenden.',
           },
-          q6: {
+          q5: {
             question:
               'Gibt es einen Branding-Leitfaden mit Logos oder Bildern die ich verwenden kann?',
             answer:

--- a/app/static/lang/en-US.js
+++ b/app/static/lang/en-US.js
@@ -1,5 +1,5 @@
 export default () => {
-  return new Promise(function(resolve) {
+  return new Promise(function (resolve) {
     resolve({
       common: {
         title: '',
@@ -157,19 +157,14 @@ export default () => {
           q3: {
             question: 'How do I get Lotus?',
             answer:
-              'You can use our <a href="https://faucet.lotuslounge.org/" target="_blank">faucet</a>. Or you can get gifted on our <a href="https://t.me/givelotus" target="_blank">telegram group</a>. You can also trade your other coins for Lotus [XPI] on <a href="https://www.exbitron.com/" target="_blank">Exbitron exchange</a>.',
+              'You can use our <a href="https://faucet.lotuslounge.org/" target="_blank">faucet</a>. Or you can get gifted on our <a href="https://t.me/givelotus" target="_blank">telegram group</a>.',
           },
           q4: {
-            question: 'Where can I trade?',
-            answer:
-              'You can trade Lotus on Exbitron for <a href="https://www.exbitron.com/trading/xpiusdt" target="_blank">USDT</a>, <a href="https://www.exbitron.com/trading/xpidoge" target="_blank">Dogecoin</a> and <a href="https://www.exbitron.com/trading/xpibch" target="_blank">Bitcoin Cash</a>',
-          },
-          q5: {
             question: 'How can I contribute to the project?',
             answer:
               'Check the open source code we have <a href="https://github.com/LogosFoundation" target="_blank">here</a> and feel free to contact developers on our <a href="https://t.me/givelotus" target="_blank">telegram group</a>.',
           },
-          q6: {
+          q5: {
             question:
               'Do you have any branding guides with logos or images I can use?',
             answer:

--- a/app/static/lang/hi-HI.js
+++ b/app/static/lang/hi-HI.js
@@ -1,5 +1,5 @@
 export default () => {
-  return new Promise(function(resolve) {
+  return new Promise(function (resolve) {
     resolve({
       common: {
         title: '',
@@ -156,19 +156,14 @@ export default () => {
           q3: {
             question: 'मुझे लोटस कैसे मिलेगा?',
             answer:
-              'आप इसका इस्तेमाल कर सकते हैं <a href="https://faucet.lotuslounge.org/" target="_blank">faucet</a>. या आप इस पर उपहार पा सकते हैं <a href="https://t.me/givelotus" target="_blank">telegram group</a>. आप लोटस [एक्सपीआई] के लिए अपने अन्य सिक्कों का व्यापार भी कर सकते हैं <a href="https://www.exbitron.com/" target="_blank">Exbitron exchange</a>.',
+              'आप इसका इस्तेमाल कर सकते हैं <a href="https://faucet.lotuslounge.org/" target="_blank">faucet</a>. या आप इस पर उपहार पा सकते हैं <a href="https://t.me/givelotus" target="_blank">telegram group</a>.',
           },
           q4: {
-            question: 'मैं कहां ट्रेड कर सकता हूं?',
-            answer:
-              'आप Exbitron पर लोटस का व्यापार निम्न के लिए कर सकते हैं<a href="https://www.exbitron.com/trading/xpiusdt" target="_blank"> USDT</a>, <a href="https://www.exbitron.com/trading/xpidoge" target="_blank">Dogecoin</a> and <a href="https://www.exbitron.com/trading/xpibch" target="_blank">Bitcoin Cash</a>',
-          },
-          q5: {
             question: 'मैं इस परियोजना में कैसे योगदान कर सकता हूं?',
             answer:
               'हमारे पास मौजूद ओपन सोर्स कोड की जांच करें <a href="https://github.com/LogosFoundation" target="_blank"> यहाँ </a> और हमारे पर डेवलपर्स से संपर्क करने में संकोच न करें <a href="https://t.me/givelotus" target="_blank">telegram group</a>.',
           },
-          q6: {
+          q5: {
             question:
               'क्या आपके पास लोगो या छवियों के साथ कोई ब्रांडिंग गाइड है जिसका मैं उपयोग कर सकता हूँ?',
             answer:

--- a/app/static/lang/pl-PL.js
+++ b/app/static/lang/pl-PL.js
@@ -1,5 +1,5 @@
 export default () => {
-  return new Promise(function(resolve) {
+  return new Promise(function (resolve) {
     resolve({
       common: {
         title: '',
@@ -154,19 +154,14 @@ export default () => {
           q3: {
             question: 'Jak zdobyć Lotusa?',
             answer:
-              'Możesz użyć naszego <a href="https://faucet.lotuslounge.org/" target="_blank">fauceta</a>. Lub możesz dostać go w prezencei na naszej grupie <a href="https://t.me/givelotus" target="_blank">na telegramie</a>. Możesz również wymienić swoje inne monety na Lotus [XPI] na <a href="https://www.exbitron.com/" target="_blank">Exbitron exchange</a>.',
+              'Możesz użyć naszego <a href="https://faucet.lotuslounge.org/" target="_blank">fauceta</a>. Lub możesz dostać go w prezencei na naszej grupie <a href="https://t.me/givelotus" target="_blank">na telegramie</a>.',
           },
           q4: {
-            question: 'Gdzie mogę handlować?',
-            answer:
-              'Na giełdzie Exbitron można handlować Lotusem z <a href="https://www.exbitron.com/trading/xpiusdt" target="_blank">USDT</a>, <a href="https://www.exbitron.com/trading/xpidoge" target="_blank">Dogecoin</a> oraz <a href="https://www.exbitron.com/trading/xpibch" target="_blank">Bitcoin Cash</a>',
-          },
-          q5: {
             question: 'Jak mogę wesprzeć projekt?',
             answer:
               'Sprawdź otwarty kod źródłowy, który mamy <a href="https://github.com/LogosFoundation" target="_blank">tutaj</a> i nie krępuj się skontaktować z deweloperami na naszej <a href="https://t.me/givelotus" target="_blank">grupie telegramowej</a>.',
           },
-          q6: {
+          q5: {
             question:
               'Czy są jakieś przewodniki brandingowe z logotypami lub obrazami, których mogę użyć?',
             answer:

--- a/app/static/lang/vi-VI.js
+++ b/app/static/lang/vi-VI.js
@@ -158,19 +158,14 @@ export default () => {
           q3: {
             question: 'Làm sao để tôi có được Lotus?',
             answer:
-              'Bạn có thể dùng <a href="https://faucet.lotuslounge.org/" target="_blank">faucet</a>. Hoặc bạn có thể nhận quà từ <a href="https://t.me/givelotus" target="_blank">telegram group</a>. Bạn cũng có thể giao dịch những đồng tiền khác thành LOTUS [XPI] trên trang <a href="https://www.exbitron.com/" target="_blank">Exbitron exchange</a>.',
+              'Bạn có thể dùng <a href="https://faucet.lotuslounge.org/" target="_blank">faucet</a>. Hoặc bạn có thể nhận quà từ <a href="https://t.me/givelotus" target="_blank">telegram group</a>.',
           },
           q4: {
-            question: 'Tôi có thể giao dịch ở đâu?',
-            answer:
-              'Bạn có thể giao dịch trên Exbitron <a href="https://www.exbitron.com/trading/xpiusdt" target="_blank">USDT</a>, <a href="https://www.exbitron.com/trading/xpidoge" target="_blank">Dogecoin</a> và <a href="https://www.exbitron.com/trading/xpibch" target="_blank">Bitcoin Cash</a>',
-          },
-          q5: {
             question: 'Tôi có thể đóng góp cho dự án như thế nào?',
             answer:
               'Hãy tham khảo mã nguồn mở của chúng tôi <a href="https://github.com/LogosFoundation" target="_blank">here</a> và đừng ngại liên hệ với các lập trình viên trên <a href="https://t.me/givelotus" target="_blank">telegram group</a>.',
           },
-          q6: {
+          q5: {
             question:
               ' Có bất kỳ hướng dẫn quảng bá thương hiệu cùng với logo và hình ảnh nào mà tôi có thể sử dụng không?',
             answer:

--- a/app/static/lang/zh-CN.js
+++ b/app/static/lang/zh-CN.js
@@ -1,5 +1,5 @@
 export default () => {
-  return new Promise(function(resolve) {
+  return new Promise(function (resolve) {
     resolve({
       common: {
         title: '',
@@ -149,19 +149,14 @@ export default () => {
           q3: {
             question: '如何获取Lotus?',
             answer:
-              '你可以使用 <a href="https://faucet.lotuslounge.org/" target="_blank">水龙头</a>. 或者在电报社区里面获赠： <a href="https://t.me/givelotus" target="_blank">telegram社区</a>。 你也可以在<a href="https://www.exbitron.com/" target="_blank">Exbitron交易所</a>用其他虚拟币交易获取Lotus[XPI]。',
+              '你可以使用 <a href="https://faucet.lotuslounge.org/" target="_blank">水龙头</a>. 或者在电报社区里面获赠： <a href="https://t.me/givelotus" target="_blank">telegram社区</a>',
           },
           q4: {
-            question: '可以在哪里交易？',
-            answer:
-              '你可以在Exbitron用这些币种交易： <a href="https://www.exbitron.com/trading/xpiusdt" target="_blank">USDT</a>，<a href="https://www.exbitron.com/trading/xpidoge" target="_blank">狗狗币Dogecoin</a> 和 <a href="https://www.exbitron.com/trading/xpibch" target="_blank">比特现金Bitcoin Cash</a>',
-          },
-          q5: {
             question: '我怎样才能为项目添砖加瓦',
             answer:
               '可以在<a href="https://github.com/LogosFoundation" target="_blank">这里</a>看我们的开源软件，并且欢迎在<a href="https://t.me/givelotus" target="_blank">telegram电报社群</a>里面联系我们的开发人员。',
           },
-          q6: {
+          q5: {
             question: '有没有可以使用的品牌商标或者图案？',
             answer:
               '你可以在<a href="https://storage.googleapis.com/lotus-project/Lotus%20Branding.zip" target="_blank">这里</a>下载',


### PR DESCRIPTION
We do not promote the buying or selling of Lotus. This shouldn't have ever really been on the main website.

Can't stop people, but not promoting it.