### PR TITLE
Updated link to bcPro Foundation

### DIFF
--- a/app/components/Projects/Projects.vue
+++ b/app/components/Projects/Projects.vue
@@ -61,7 +61,7 @@ export default {
         {
           title: 'bcPro',
           content: this.$t('lotusLanding.bcpro_desc'),
-          url: 'https://www.givelotus.vn/',
+          url: 'https://givelotus.vn/bcpro/',
           image: images.projects.bcpro
         },
         {


### PR DESCRIPTION
The currently with www is having redirect issues and showing warning from various browsers. Also included the path to more detailed description of the Foundation.